### PR TITLE
Updating babel-register to 6.24.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   "dependencies": {
     "babel-core": "^6.21.0",
     "babel-preset-es2015": "6.18.0",
-    "babel-register": "6.18.0",
+    "babel-register": "^6.24.0",
     "gulp": "3.9.1",
     "gulp-autoprefixer": "^3.1.1",
     "gulp-babel": "^6.1.2",


### PR DESCRIPTION

Please update [babel-register](https://npmjs.org/package/babel-register) to version 6.24.0.

If this passes your tests you can merge it in.  If not please use this branch for changes.

