### PR TITLE
Updating babel-preset-es2015 to 6.24.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   "contributors": "https://github.com/andyhqtran/Permissive/graphs/contributors",
   "dependencies": {
     "babel-core": "^6.21.0",
-    "babel-preset-es2015": "6.18.0",
+    "babel-preset-es2015": "^6.24.0",
     "babel-register": "^6.24.0",
     "gulp": "3.9.1",
     "gulp-autoprefixer": "^3.1.1",


### PR DESCRIPTION

Please update [babel-preset-es2015](https://npmjs.org/package/babel-preset-es2015) to version 6.24.0.

If this passes your tests you can merge it in.  If not please use this branch for changes.

