### PR TITLE
Updating gulp-sourcemaps to 2.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "gulp-clean-css": "^3.0.4",
     "gulp-refresh": "1.1.0",
     "gulp-sass": "2.3.2",
-    "gulp-sourcemaps": "1.9.1",
+    "gulp-sourcemaps": "^2.4.1",
     "gulp-uglify": "^2.1.2"
   },
   "devDependencies": {


### PR DESCRIPTION

Please update [gulp-sourcemaps](https://npmjs.org/package/gulp-sourcemaps) to version 2.4.1.

If this passes your tests you can merge it in.  If not please use this branch for changes.

